### PR TITLE
Class that indicates the open animation is still in progress

### DIFF
--- a/jquery.mobile.actionsheet.js
+++ b/jquery.mobile.actionsheet.js
@@ -57,14 +57,17 @@
 			$(window).bind('orientationchange.actionsheet',$.proxy(function () {
 				this._positionContent();
 			}, this));
-		
+
 			if( $.support.cssTransitions ) {
 				this.content.animationComplete(function(event) {
-						$(event.target).removeClass("ui-actionsheet-animateIn");
+						$(event.target).removeClass("ui-actionsheet-animateIn ui-actionsheet-opening");
 					});
-				this.content.addClass("ui-actionsheet-animateIn").show();
+				this.content.addClass("ui-actionsheet-animateIn ui-actionsheet-opening").show();
 			} else {
-				this.content.fadeIn();
+				this.content.addClass("ui-actionsheet-opening");
+				this.content.fadeIn(function () {
+					$(this).removeClass("ui-actionsheet-opening");
+				});
 			}
 		},
 		close: function(event) {


### PR DESCRIPTION
When using testing tools (e.g. Selenium2) it is sometimes necessary to wait for animation to finish before the tests can continue. I've added a class that indicates that the opening animation is still in progress. So automated clients can use this class to test if the animation has already finished.
